### PR TITLE
UB CCR new software instructions

### DIFF
--- a/soft_and_tuts.html
+++ b/soft_and_tuts.html
@@ -100,15 +100,21 @@
 
 ## 3. Packages we use 
 
- 3.1. [Gaussian](soft_and_tuts/3.1-gaussian.html)
+ 3.1. [CP2K](soft_and_tuts/3.1-cp2k.html)
 
- 3.2. [PSI4](http://www.psicode.org/) \(Official site\)
+ 3.2. [NWChem](soft_and_tuts/3.2-nwchem.html)
 
- 3.3. [Quantum Espresso](https://www.quantum-espresso.org/) \(Official site\)
+ 3.3. [DFTB+](soft_and_tuts/3.3-dftb+.html)
 
- 3.4. [DFTB+](https://www.dftbplus.org/) \(Official site\)
+ 3.4. [Libra](soft_and_tuts/3.4-libra.html)
 
- 3.5. [ErgoSCF](http://www.ergoscf.org/) \(Official site\)
+ 3.5. [ORCA](https://orcaforum.kofo.mpg.de/app.php/portal) \(Official site\)
+
+ 3.6. [PSI4](http://www.psicode.org/) \(Official site\)
+
+ 3.7. [Quantum Espresso](https://www.quantum-espresso.org/) \(Official site\)
+
+ 3.8. [ErgoSCF](http://www.ergoscf.org/) \(Official site\)
 
 
 ## 4. Center for Computational Research (CCR) at UB

--- a/soft_and_tuts/3.1-cp2k.html
+++ b/soft_and_tuts/3.1-cp2k.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+
+  <head>
+    <title>The Akimov Research Group</title>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-119266503-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-119266503-1');
+    </script>
+
+  </head>
+
+
+  <body>    
+    <!-- Navigation bar  style="margin-top:-2px;" -->
+    <nav class="navbar navbar-expand-sm bg-dark navbar-dark fixed-top">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="../index.html">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="../research.html">Research</a></li>
+        <li class="nav-item"><a class="nav-link" href="../publications.html">Publications</a></li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbardrop" data-toggle="dropdown">Group</a>
+          <div class="dropdown-menu">
+            <a class="dropdown-item" href="../group.html">Present</a>
+            <a class="dropdown-item" href="../group_alumni.html">Former Members and Visitors</a>
+          </div>
+        </li>        
+        <li class="nav-item"><a class="nav-link" href="../teaching.html">Teaching</a></li>
+        <li class="nav-item"><a class="nav-link" href="../outreach.html">Outreach</a></li>
+        <li class="nav-item active"><a class="nav-link" href="../soft_and_tuts.html">Software &amp; Tutorials</a></li>
+        <li class="nav-item"><a class="nav-link" href="../gallery.html">Gallery</a></li>
+        <li class="nav-item"><a class="nav-link" href="../contact.html">Contact</a></li>
+        <li><a href="https://twitter.com/AkimovLab" class="twitter-follow-button" data-show-count="false" data-lang="en-gb">Follow @AkimovLab</a>
+          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
+            if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';
+            fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+        </li>
+      </ul>
+    </nav>
+
+
+<xmp theme="bootstrap"> 
+# 3.1. CP2K on UB CCR
+
+[CP2K](https://www.cp2k.org/) is a quantum chemistry and solid state physics software package that can perform atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. CP2K provides a general framework for different modeling methods such as DFT using the mixed Gaussian and plane waves approaches GPW and GAPW. Supported theory levels include DFTB, LDA, GGA, MP2, RPA, semi-empirical methods (AM1, PM3, PM6, RM1, MNDO, …), and classical force fields (AMBER, CHARMM, …). CP2K can do simulations of molecular dynamics, metadynamics, Monte Carlo, Ehrenfest dynamics, vibrational analysis, core level spectroscopy, energy minimization, and transition state optimization using NEB or dimer method. (Detailed overview of features.)
+
+## A. Installation
+
+
+To install CP2K, we use the instruction in [here](https://github.com/cp2k/cp2k/blob/master/INSTALL.md) and a recipe for installing it on UB CCR using GNU compilers is provided below. For compilation using Intel compiler see [this link](https://github.com/compchem-cybertraining/Tutorials_CP2K/blob/master/INSTALLATION.md).
+
+    git clone --recursive -b support/v2024.1 https://github.com/cp2k/cp2k.git cp2k
+    cd cp2k/tools/toolchain
+    module load gcc/11.2.0
+    module load openmpi/4.1.1
+    module load imkl/2022.0.1
+    module load cmake/3.22.1
+    ./install_cp2k_toolchain.sh --with-gcc=system --with-mkl=system --with-cmake=system --with-sirius=no --with-openmpi=system
+
+In order to see more options you can type `./install_cp2k_toolchain.sh --help`. Then, the toolchain will download and install the necessary files and create arch files in the install directory. Copy and paste the arch files to the `cp2k/arch` directory by:
+
+
+```
+cp install/arch/local* ../../arch/.
+```
+
+In order to `make` CP2K, do the following commands:
+
+```
+source install/setup # You need to source this file in the install directory before installation
+cd ../..
+make -j 16 ARCH=local VERSION=psmp
+```
+
+
+After compilation is finished, create a module file in the modules directory (`/projects/academic/cyberwksp21/MODULES`) with the following content:
+
+```
+whatis("Description: CP2K")
+whatis("Version: 2024.1")
+whatis("Category: Chem")
+load("ccrsoft/2023.01")
+load("imkl/2022.0.1")
+load("gcc/11.2.0")
+load("openmpi/4.1.1")
+prepend_path("PATH","/projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/cp2k/cp2k_v24/exe/local")
+prepend_path("LD_LIBRARY_PATH","/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/Core/imkl/2022.0.1/mkl/2022.0.1/lib/intel64")
+prepend_path("LD_LIBRARY_PATH","/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/avx512/Compiler/gcc/11.2.0/openmpi/4.1.1/lib64")
+prepend_path("LD_LIBRARY_PATH","/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/Core/gcccore/11.2.0/lib64")
+setenv("OMP_NUM_THREADS","1")
+add_property("type_","chem")
+```
+
+## B. Running CP2K
+
+See the following script for an example of running a computation with CP2K.
+
+Here is an example to run on our cluster: 
+
+    #!/bin/sh
+    #SBATCH --partition=general-compute  --qos=general-compute
+    #SBATCH --clusters=ub-hpc
+    #SBATCH --nodes=1
+    #SBATCH --ntasks-per-node=6
+    #SBATCH --cpus-per-task=1
+    #SBATCH --time=00:10:00
+    #SMATCH --mem=10000
+    ###SBATCH -C CPU-E5-2650v4 # This is the type of CPUs on valhalla nodes
+    #SBATCH -C CPU-Gold-6130 # The head node CPU type for not getting warnings or errors
+
+    module use /projects/academic/cyberwksp21/MODULES
+    module load cp2k/v24/avx512
+    mpirun -np 6 cp2k.psmp -i input.inp -o out
+
+    
+## C. Input Example
+
+### C.1. Single point calculations of water molecule at the B3LYP level of theory:
+
+```
+&GLOBAL
+  #  TRACE
+  PRINT_LEVEL MEDIUM
+  PROJECT H2O-hybrid-b3lyp_libxc
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME EMSL_BASIS_SETS
+    POTENTIAL_FILE_NAME POTENTIAL
+    &MGRID
+      CUTOFF 250
+      REL_CUTOFF 50
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END POISSON
+    &QS
+      METHOD GAPW
+    &END QS
+    &SCF
+      EPS_SCF 1.0E-6
+      IGNORE_CONVERGENCE_FAILURE
+      MAX_SCF 2
+      SCF_GUESS ATOMIC
+    &END SCF
+    #This is B3LYP using VWN3
+    &XC
+      &HF
+        FRACTION 0.20
+        !&MEMORY
+        !  MAX_MEMORY 5
+        !&END MEMORY
+        &SCREENING
+          EPS_SCHWARZ 1.0E-10
+        &END SCREENING
+      &END HF
+      &XC_FUNCTIONAL
+        &HYB_GGA_XC_B3LYP
+        &END HYB_GGA_XC_B3LYP
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 6.0 6.0 6.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O   0.000000    0.000000   -0.065587
+      H   0.000000   -0.757136    0.520545
+      H   0.000000    0.757136    0.520545
+    &END COORD
+    &KIND H
+      BASIS_SET 6-31Gxx
+      POTENTIAL ALL
+    &END KIND
+    &KIND O
+      BASIS_SET 6-31Gxx
+      POTENTIAL ALL
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL
+```
+</xmp>
+
+
+  <script type="text/javascript" src="https://cdn.rawgit.com/Naereen/StrapDown.js/master/strapdown.min.js"></script>
+  </body>
+</html>

--- a/soft_and_tuts/3.2-nwchem.html
+++ b/soft_and_tuts/3.2-nwchem.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+
+  <head>
+    <title>The Akimov Research Group</title>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-119266503-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-119266503-1');
+    </script>
+
+  </head>
+
+
+  <body>    
+    <!-- Navigation bar  style="margin-top:-2px;" -->
+    <nav class="navbar navbar-expand-sm bg-dark navbar-dark fixed-top">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="../index.html">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="../research.html">Research</a></li>
+        <li class="nav-item"><a class="nav-link" href="../publications.html">Publications</a></li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbardrop" data-toggle="dropdown">Group</a>
+          <div class="dropdown-menu">
+            <a class="dropdown-item" href="../group.html">Present</a>
+            <a class="dropdown-item" href="../group_alumni.html">Former Members and Visitors</a>
+          </div>
+        </li>        
+        <li class="nav-item"><a class="nav-link" href="../teaching.html">Teaching</a></li>
+        <li class="nav-item"><a class="nav-link" href="../outreach.html">Outreach</a></li>
+        <li class="nav-item active"><a class="nav-link" href="../soft_and_tuts.html">Software &amp; Tutorials</a></li>
+        <li class="nav-item"><a class="nav-link" href="../gallery.html">Gallery</a></li>
+        <li class="nav-item"><a class="nav-link" href="../contact.html">Contact</a></li>
+        <li><a href="https://twitter.com/AkimovLab" class="twitter-follow-button" data-show-count="false" data-lang="en-gb">Follow @AkimovLab</a>
+          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
+            if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';
+            fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+        </li>
+      </ul>
+    </nav>
+
+
+<xmp theme="bootstrap"> 
+# 3.2. NWChem on UB CCR
+
+The [NWChem](https://nwchemgit.github.io/index.html) software contains computational chemistry tools that are scalable both in their ability to efficiently treat large scientific problems, and in their use of available computing resources from high-performance parallel supercomputers to conventional workstation clusters. 
+
+## A. Installation
+
+To install the NWChem, we use the instruction in [here](https://nwchemgit.github.io/Compiling-NWChem.html) and a recipe for installing it on UB CCR is provided below. First create a file called `setup_env.sh`:
+
+
+    #!/bin/bash
+    module purge
+    conda deactivate # Make sure no conda environment is active
+
+    export NWCHEM_TOP=/projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/nwchem
+    export NWCHEM_TARGET=LINUX64
+    export NWCHEM_MODULES="all xtb"
+    export ARMCI_NETWORK=MPI-PR
+    export USE_MPI=1
+
+    export USE_TBLITE=1
+    export USE_HWOPT=1
+    export USE_OPENMP=1
+    export USE_LIBXC=1
+    export USE_SIMINT=1
+    export SIMINT_MAXAM=5
+    #export BUILD_PLUMED=0
+    export BUILD_SCALAPACK=1
+    #export BUILD_ELPA=1 
+    
+    module load gcc/11.2.0
+    module load openmpi/4.1.1
+    module load imkl/2022.0.1
+    module load cmake/3.22.1
+    
+    export LD_LIBRARY_PATH=${LIBRARY_PATH}:${CMAKE_LIBRARY_PATH}
+    
+    export FC=gfortran
+    export CC=gcc
+    export CXX=g++
+    export BLAS_SIZE=8
+    export SCALAPACK_SIZE=${BLAS_SIZE}
+    export BLASOPT="-L${MKLROOT}/lib/intel64 -lmkl_gf_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl"
+    export LAPACK_LIB=${BLASOPT}
+
+
+For compiling NWChem using Intel compilers you need to modify some of the above lines as follows:
+
+    module load intel/2022.00
+    module load cmake/3.22.1
+    
+    export LD_LIBRARY_PATH=${LIBRARY_PATH}:${CMAKE_LIBRARY_PATH}
+    
+    export FC=ifort
+    export CC=icc 
+    export CXX=icpc # If this didn't work for SimintFortran use mpicxx
+   
+Then:
+
+    source setup_env.sh
+    cd /projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/nwchem/src
+    make -j8
+
+After compilation is finished, create a module file in the modules directory (`/projects/academic/cyberwksp21/MODULES`) with the following content:
+
+    whatis("Description: NWChem ")
+    whatis("Version: 7.2.2")
+    whatis("Category: Chem")
+    load("ccrsoft/2023.01")
+    load("imkl/2022.0.1")
+    load("gcc/11.2.0")
+    load("openmpi/4.1.1")
+    prepend_path("PATH","/projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/nwchem/bin/LINUX64")
+    prepend_path("LD_LIBRARY_PATH","/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/Core/imkl/2022.0.1/mkl/2022.0.1/lib/intel64")
+    prepend_path("LD_LIBRARY_PATH","/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/avx512/Compiler/gcc/11.2.0/openmpi/4.1.1/lib64")
+    setenv("OMP_NUM_THREADS","1")
+    add_property("type_","chem")
+
+
+## B. Running NWChem
+
+See the following script for an example of running a computation with NWChem.
+
+Here is an example to run on our cluster: 
+
+    #!/bin/sh
+    #SBATCH --partition=general-compute  --qos=general-compute
+    #SBATCH --clusters=ub-hpc
+    #SBATCH --nodes=1
+    #SBATCH --ntasks-per-node=6
+    #SBATCH --cpus-per-task=1
+    #SBATCH --time=00:10:00
+    #SMATCH --mem=10000
+    ###SBATCH -C CPU-E5-2650v4 # This is the type of CPUs on valhalla nodes
+    #SBATCH -C CPU-Gold-6130 # The head node CPU type for not getting warnings or errors
+
+    module use /projects/academic/cyberwksp21/MODULES
+    module load nwchem/gnu/7.2.2
+    # Other compiled versions are also available
+    # module load nwchem/intel/7.2.2
+    mpirun -np 6 nwchem b3lyp.nw > out
+
+    
+## C. Input Example
+
+### C.1. Single point calculations of benzene molecule at the B3LYP level
+
+    echo
+    title "total energy of benzene, B3LYP/3-21G"
+    
+    start c6h6-b3lyp
+    
+    geometry
+     C    0.99261000     0.99261000     0.00000000
+     C   -1.35593048     0.36332048     0.00000000
+     C    0.36332048    -1.35593048     0.00000000
+     C   -0.99261000    -0.99261000     0.00000000
+     C    1.35593048    -0.36332048     0.00000000
+     C   -0.36332048     1.35593048     0.00000000
+     H    1.75792000     1.75792000     0.00000000
+     H   -2.40136338     0.64344338     0.00000000
+     H    0.64344338    -2.40136338     0.00000000
+     H   -1.75792000    -1.75792000     0.00000000
+     H    2.40136338    -0.64344338     0.00000000
+     H   -0.64344338     2.40136338     0.00000000
+    end
+    
+    basis
+    * library 3-21G
+    end
+    
+    dft
+      xc b3lyp
+    end
+    
+    task dft energy
+
+</xmp>
+
+
+  <script type="text/javascript" src="https://cdn.rawgit.com/Naereen/StrapDown.js/master/strapdown.min.js"></script>
+  </body>
+</html>

--- a/soft_and_tuts/3.3-dftb+.html
+++ b/soft_and_tuts/3.3-dftb+.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+
+  <head>
+    <title>The Akimov Research Group</title>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-119266503-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-119266503-1');
+    </script>
+
+  </head>
+
+
+  <body>    
+    <!-- Navigation bar  style="margin-top:-2px;" -->
+    <nav class="navbar navbar-expand-sm bg-dark navbar-dark fixed-top">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="../index.html">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="../research.html">Research</a></li>
+        <li class="nav-item"><a class="nav-link" href="../publications.html">Publications</a></li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbardrop" data-toggle="dropdown">Group</a>
+          <div class="dropdown-menu">
+            <a class="dropdown-item" href="../group.html">Present</a>
+            <a class="dropdown-item" href="../group_alumni.html">Former Members and Visitors</a>
+          </div>
+        </li>        
+        <li class="nav-item"><a class="nav-link" href="../teaching.html">Teaching</a></li>
+        <li class="nav-item"><a class="nav-link" href="../outreach.html">Outreach</a></li>
+        <li class="nav-item active"><a class="nav-link" href="../soft_and_tuts.html">Software &amp; Tutorials</a></li>
+        <li class="nav-item"><a class="nav-link" href="../gallery.html">Gallery</a></li>
+        <li class="nav-item"><a class="nav-link" href="../contact.html">Contact</a></li>
+        <li><a href="https://twitter.com/AkimovLab" class="twitter-follow-button" data-show-count="false" data-lang="en-gb">Follow @AkimovLab</a>
+          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
+            if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';
+            fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+        </li>
+      </ul>
+    </nav>
+
+
+<xmp theme="bootstrap"> 
+# 3.3. DFTB+ on UB CCR
+
+[DFTB+](https://dftbplus.org/) is a fast and efficient versatile quantum mechanical simulation software package. Using DFTB+ you can carry out quantum mechanical simulations similar to density functional theory but in an approximate way, typically gaining around two orders of magnitude in speed.
+ 
+## A. Installation
+
+To install DFTB+, we use the instruction in [here](https://github.com/dftbplus/dftbplus/blob/main/INSTALL.rst) and a recipe for installing it on UB CCR is provided below:
+
+    
+    module load foss
+    module load arpack-ng
+    module load cmake
+    cd /projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/dftb+/dftbplus-23.1 # where you downloaded or cloned the DFTB+ code
+    FC=gfortran CC=gcc cmake -DWITH_ARPACK=Y -DCMAKE_INSTALL_PREFIX=/projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/dftb+/dftbplus-23.1/install -B _build .
+    cmake --build _build -- -j
+    ./utils/get_opt_externals ALL
+    cmake --install _build
+
+After compilation is finished, create a module file in the modules directory (`/projects/academic/cyberwksp21/MODULES`) with the following content:
+
+```
+whatis("Description: DFTB+")
+whatis("Version: 23.1")
+whatis("Category: Chem")
+load("ccrsoft/2023.01")
+load("foss/2021b")
+load("arpack-ng/3.8.0")
+prepend_path("PATH","/projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/dftb+/dftbplus-23.1/install/bin")
+prepend_path("LD_LIBRARY_PATH","/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/avx512/MPI/gcc/11.2.0/openmpi/4.1.1/arpack-ng/3.8.0/lib")
+prepend_path("LD_LIBRARY_PATH","/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/avx512/Compiler/gcc/11.2.0/flexiblas/3.0.4/lib")
+prepend_path("LD_LIBRARY_PATH","/cvmfs/soft.ccr.buffalo.edu/versions/2023.01/easybuild/software/Core/gcccore/11.2.0/lib64")
+add_property("type_","chem")
+```
+
+## B. Running DFTB+
+
+See the following example of running a computation with DFTB+.
+
+Here is an example to run on our cluster: 
+
+    #!/bin/sh
+    #SBATCH --partition=general-compute  --qos=general-compute
+    #SBATCH --clusters=ub-hpc
+    #SBATCH --nodes=1
+    #SBATCH --ntasks-per-node=6
+    #SBATCH --cpus-per-task=1
+    #SBATCH --time=00:10:00
+    #SMATCH --mem=10000
+    ###SBATCH -C CPU-E5-2650v4 # This is the type of CPUs on valhalla nodes
+    #SBATCH -C CPU-Gold-6130 # The head node CPU type for not getting warnings or errors
+
+    module use /projects/academic/cyberwksp21/MODULES
+    module load dftb+/v23
+    dftb+ > out
+
+    
+## C. Input Example
+
+### C.1. Single point/molecular dynamics calculations of C60 fullerene.
+
+```
+Geometry = xyzFormat {
+<<< "c60.xyz"
+}
+# For molecular dynamics
+#Driver = VelocityVerlet{
+#  TimeStep [fs] = 1.0
+#  Thermostat = NoseHoover {
+#    Temperature [Kelvin] = 300
+#    CouplingStrength [cm^-1] = 1374
+#  }  
+#  Steps = 5000
+#  MovedAtoms = 1:-1
+#  MDRestartFrequency = 1
+#}
+
+
+Hamiltonian = DFTB {
+  SCC = Yes
+  Charge = 0
+  SCCTolerance = 1e-6
+  SlaterKosterFiles = Type2FileNames {
+    Prefix = "mio-1-1/"
+    Separator = "-"
+    Suffix = ".skf"
+  }
+  MaxAngularMomentum = {
+    C = "p"
+  }
+  #ReadInitialCharges = Yes
+  Dispersion = LennardJones {
+    Parameters = UFFParameters{}
+  }
+}
+
+
+Options = {
+#  WriteAutotestTag = Yes
+#  WriteHS = Yes
+}
+
+Analysis = {
+WriteEigenvectors = Yes
+#WriteEigenvectorsAsTxt = Yes
+}
+
+ParserOptions = {
+  ParserVersion = 4
+}
+```
+
+</xmp>
+
+
+  <script type="text/javascript" src="https://cdn.rawgit.com/Naereen/StrapDown.js/master/strapdown.min.js"></script>
+  </body>
+</html>

--- a/soft_and_tuts/3.4-libra.html
+++ b/soft_and_tuts/3.4-libra.html
@@ -52,86 +52,54 @@
 
 
 <xmp theme="bootstrap"> 
-# 3.1. Running Gaussian on CCR
+# 3.4. Libra code on UB CCR
 
-## A. General info
+[Libra code](https://github.com/Quantum-Dynamics-Hub/libra-code) is a modular methodology prototyping library for quantum dynamics, written in C++ and Python. Libra enables quantum–classical dynamics calculations with model and atomistic Hamiltonians. Libra boasts a comprehensive set of trajectory surface hopping methods and algorithms for nonadiabatic dynamics. 
 
-GAUSSIAN 16 is available for use on the faculty clusters. 
-Here is a link to what is new:  [http://gaussian.com/g16new/](http://gaussian.com/g16new/)
+## A. Using Libra
 
-GAUSSIAN 16 is installed in /util/academic/gaussian/g16.A03.  
-There are binaries for several extensions to the x86 instruction set architecture.
-
-    [cdc@rush:/util/academic/gaussian/g16.A03]$ ls
-    gaussian.slurm  modules  x86-64-AVX  x86-64-AVX2  x86-64-Legacy  x86-64-SSE4_2
-
-There is a module for each set of binaries.  
-
-    [cdc@rush:/util/academic/gaussian/g16.A03]$ ls modules/
-
-    g16  g16.A03-AVX2.lua  g16.A03-AVX.lua  g16.A03-Legacy.lua  g16.A03-SSE4_2.lua
+To install Libra, we use the instruction in [here](https://github.com/Quantum-Dynamics-Hub/libra-code). It is already installed on CCR and in order to load it, one needs to follow these steps:
 
 
-The g16 module determines the most recent extension available on the compute node and loads the appropriate module.
+```
+module use /projects/academic/cyberwksp21/MODULES
+module load libra/v5.5.0 # Other versions are also available: v5.3.0 and the devel branch of the code in github repository.
+```
 
-See the SLURM script gaussian.slurm for an example of running a computation with GAUSSIAN 16. 
+Using the above command it will load the `libra` environment and one can test the loading by:
 
-Here is an example to run on our cluster: 
+```
+python -c "from liblibra_core import *"
+```
 
-    #!/bin/sh
-    #SBATCH --cluster=faculty
-    #SBATCH --partition=valhalla --qos=valhalla
-    #SBATCH --time=00:20:00
-    #SBATCH --nodes=1
-    #SBATCH --ntasks-per-node=12
-    ###SBATCH --exclusive
-    #SBATCH --job-name="test"
-    #SBATCH --output=slurm-test.out
-    ###SBATCH --mail-user=alexeyak@buffalo.edu
-    ###SBATCH --mail-type=ALL
-    
-    echo "working directory = "$SLURM_SUBMIT_DIR
-    echo "SLURMTMPDIR="$SLURMTMPDIR
-    
-    ulimit -s unlimited
-    
-    module use /util/academic/gaussian/g16.A03/modules
-    module load g16
-    module list
-    
-    echo "g16root="$g16root
-    echo "Default location for GAUSS_SCRDIR="$GAUSS_SCRDIR
-    echo "Changing $GAUSS_SCRDIR to $SLURMTMPDIR"
-    export GAUSS_SCRDIR=$SLURMTMPDIR
-    echo "GAUSS_SCRDIR="$GAUSS_SCRDIR
-    #
-    echo "Sourcing the g16.profile"
-    . $g16root/g16/bsd/g16.profile
-    echo "G16 variables from sourcing"
-    export | grep -i g16
-    which g16
-    
-    echo "Launch GAUSSIAN"
-    time g16 < test.inp >& test.out
-    #
-    echo "All Done!"
+## B. Using on Jupyter notebook
 
-GAUSSIAN 16 is not available in WebMO.  We are waiting to the developer to release an update that supports GAUSSIAN 16.
+In order to use it on Jupyter notebook, you need to follow these steps:
 
-## B. Input Examples
+You first need to install Jupyter notebook manually on your terminal. This is a one time setup and you don't need to do this anymore you want to use Jupyter on CCR.
 
-### B.1. Single point calculations of water molecule at the Hartree-Fock level
+```
+module use /projects/academic/cyberwksp21/MODULES
+module load libra
+pip install jupyterlab
+```
 
-    %Chk=heavy                   
-    # HF/6-31G(d)
-    
-    water
-    
-    0   1
-    O  -0.464   0.177   0.0
-    H  -0.464   1.137   0.0
-    H   0.441  -0.143   0.0
+Then, create your own kernel by:
 
+```
+python -m ipykernel install --user --name=libra_kernel
+```
+
+Since the Jupyter lab on CCR resets every module before running the Jupyter notebook interface, you need to properly specify the `PYTHONPATH` and `LD_LIBRARY_PATH` variables to the `_build/src` directory for each version of libra installed in your `~/.bashrc` file as follows (e.g. v5.5.0):
+
+```
+export PYTHONPATH=/projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/libra/v5.5.0/_build/src:$PYTHONPATH
+export LD_LIBRARY_PATH=/projects/academic/cyberwksp21/SOFTWARE_NEW_ENV/libra/v5.5.0/_build/src:$LD_LIBRARY_PATH
+```
+
+Then, from OnDemand, load a JupyterLab job and after jupyter is run, select the `libra_kernel` whenever you want to run a calculations that requires Libra's modules.
+
+**Note:** This only works with Jupyter Lab (legacy) version for now and will not be working by June 2024.
 
 </xmp>
 


### PR DESCRIPTION
Added the software instructions for installation and running on UB CCR in html format to akimovlab.github.io for:
- NWChem
- CP2K
- DFTB+
- Libra code
- ORCA
The instructions show how installation is done for each software using the 2023 CCR software environment and how they can be run on CCR nodes.